### PR TITLE
Remove async functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ let handlers = {
   //     this.response.speak(userLocation + " has been set");
   //     this.emit(':responseReady');
   //   },
-  'recordIntent': async function() {
+  'recordIntent': function() {
     let date = new Date();
     let startTime = `${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}`;
     let dateStamp = `${date.getMonth()}-${date.getDate()}-${date.getFullYear()}`;
@@ -46,17 +46,16 @@ let handlers = {
         "date": dateStamp,
       }
     };
-    await ddb.put(params,(err,data)=>{
+    ddb.put(params,(err,data)=>{
       if (err){
         console.log(err)
       }else{
         console.log(data)
+        this.emit(":ask", "Recording");
       }
-    }).promise();
-    this.emit(":ask", "Recording");
-
+    });
   },
-  'stopRecordingintent': async function(){
+  'stopRecordingintent': function(){
     //failure here//
     let date = new Date();
     let endTime = `${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}`;
@@ -72,16 +71,15 @@ let handlers = {
       },
       ReturnValues:"UPDATED_NEW"
     };
-    await ddb.update(params,(err,data)=>{
+    ddb.update(params,(err,data)=>{
       if (err){
         this.response.speak(err);
         this.emit(':responseReady');
       }else{
         this.emit(":ask", "Ending recording, say seizure type or skip to end session.");
       }
-    }).promise();
-
-  },'seizureTypeintent': async function(){
+    });
+  },'seizureTypeintent': function(){
     let date = new Date();
     let seizureCategory = this.event.request.intent.slots.seizure.value;
 
@@ -98,14 +96,14 @@ let handlers = {
       ReturnValues:"UPDATED_NEW"
     };
 
-    await ddb.update(params,(err,data)=>{
+    ddb.update(params,(err,data)=>{
       if (err){
         console.log(err)
       }else{
         this.response.speak("Information has been recorded.")
         this.emit(':responseReady');
       }
-    }).promise();
+    });
 
     //end
   }


### PR DESCRIPTION
Hi @SelamawitA!

Here's some changes to try.

I don't think you need `async` functions, and they may in fact be causing problems here. All of your `ddb` calls are passing callback arguments, so you shouldn't need to use promises as well. Also, an `async` function returns a promise, and that means the _caller_ of the `async` function  - in your case, the Skills framework - needs to deal with the promise correctly. I wouldn't assume that they do that.

For `recordIntent`, the other change to make is to move the call to `emit` from the end of the function into the success callback from the dynamodb call. You have to do that to make the function not be `async` anymore.

Try this and let me know what happens!